### PR TITLE
Update @types and tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "zone.js": "0.8.18"
   },
   "devDependencies": {
-    "@types/core-js": "0.9.34",
-    "@types/node": "6.0.45",
+    "@types/core-js": "0.9.43",
+    "@types/node": "8.0.31",
     "concurrently": "3.5.0",
     "typescript": "2.5.3",
     "electron": "1.7.8"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,11 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "removeComments": false,
-        "noImplicitAny": false
+        "noImplicitAny": false,
+        "lib": [
+            "es6",
+            "dom"
+        ]
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
`@types/core-js` and `@types/node` also updated to latest version as of September 2017

These changes required the following addition to `tsconfig.json`:
```
        "lib": [
            "es6",
            "dom"
        ]
```